### PR TITLE
Remove tilejson item in zoom level listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiny-tileserver",
   "description": "Tiny raster+vector tiles and static file server.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "index.js",
   "engines": {
     "node": ">=10.0.0"

--- a/src/fileformat/__snapshots__/index.test.js.snap
+++ b/src/fileformat/__snapshots__/index.test.js.snap
@@ -157,9 +157,6 @@ Object {
       "filesize": undefined,
       "name": "4",
     },
-    Object {
-      "name": "tilejson.json",
-    },
   ],
   "link": "",
   "pathSegments": Array [],

--- a/src/fileformat/mbtiles/index.js
+++ b/src/fileformat/mbtiles/index.js
@@ -26,10 +26,6 @@ class Index {
       }
       return r;
     });
-    if (level == "zoom")
-      files.push({
-        name: "tilejson.json"
-      });
     cursor.canBrowse = true;
     cursor.files = files;
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/281359/56987960-26629100-6b8f-11e9-84a3-df977d60e4bb.png)

As the link was broken and already present and works one level up 